### PR TITLE
Add brand-aware resume tailoring

### DIFF
--- a/robot_brain/main.py
+++ b/robot_brain/main.py
@@ -160,7 +160,11 @@ def main():
 
         # Use raw job description text
         print("📄 Generating tailored resume...")
-        tailored_resume = model.tailor_resume(resume_data, job_description)
+        tailored_resume = model.tailor_resume(
+            resume_json=resume_data,
+            job_description_text=job_description,
+            brand_statement_json=brand_data,
+        )
 
         print("✉️ Generating cover letter...")
         cover_letter = model.generate_cover_letter(

--- a/robot_brain/models/model_interface.py
+++ b/robot_brain/models/model_interface.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 class ResumeTailorModel(ABC):
     @abstractmethod
-    def tailor_resume(self, resume_json, job_description_text):
+    def tailor_resume(self, resume_json, job_description_text, brand_statement_json):
         pass
 
     @abstractmethod

--- a/robot_brain/models/openai_model.py
+++ b/robot_brain/models/openai_model.py
@@ -6,16 +6,15 @@ class OpenAIModel(ResumeTailorModel):
     def __init__(self, api_key):
         openai.api_key = api_key
 
-    def tailor_resume(self, resume_json, job_description_text):
-        prompt = f"""
-        You are an expert resume coach.
-        Given the following resume (in JSON) and a job description,
-        output a tailored resume that emphasizes the most relevant experience
-        and uses strong, outcome-focused language.
-
-        RESUME: {resume_json}
-        JOB DESCRIPTION: {job_description_text}
-        """
+    def tailor_resume(self, resume_json, job_description_text, brand_statement_json):
+        prompt = self.render_prompt(
+            "tailor_prompt.txt",
+            {
+                "resume_json": resume_json,
+                "job_description_text": job_description_text,
+                "brand_statement_json": brand_statement_json,
+            },
+        )
         response = openai.ChatCompletion.create(
             model="gpt-4", messages=[{"role": "user", "content": prompt}]
         )

--- a/robot_brain/prompts/tailor_prompt.txt
+++ b/robot_brain/prompts/tailor_prompt.txt
@@ -9,3 +9,4 @@ You are a resume tailoring assistant. Use this template when generating outputs:
 
 RESUME: {{resume_json}}
 JOB DESCRIPTION: {{job_description_text}}
+BRAND STATEMENT: {{brand_statement_json}}


### PR DESCRIPTION
## Summary
- add placeholder for brand statements in `tailor_prompt.txt`
- extend interface to accept brand statement when tailoring resume
- update `OpenAIModel.tailor_resume` to use prompt template
- pass brand statement into resume tailoring step

## Testing
- `pytest tests/` *(fails: file or directory not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686367b9c2e8832d8ec3391330a726aa